### PR TITLE
fix: stow error hypr-config dir not found

### DIFF
--- a/scripts/hypr.sh
+++ b/scripts/hypr.sh
@@ -17,4 +17,6 @@ if ! install_deps; then
     error_msg "Error installing dependencies !!"
 fi
 
+cd "$DOTFILES"
+
 stow_link "hypr-config"


### PR DESCRIPTION
After finishing paru installation change back to the dotfiles directory