### PR TITLE
chore: remove hyprlock numlock workaround

### DIFF
--- a/hypr-config/.config/hypr/hyprlock.conf
+++ b/hypr-config/.config/hypr/hyprlock.conf
@@ -75,8 +75,4 @@ input-field {
     position = 0, -300
     halign = center
     valign = center
-
-    # Added due to capslock color not working see github.com/hyprwm/hyprlock/issues/660
-    # Should be removed in v0.7.0
-    invert_numlock = true
 }


### PR DESCRIPTION
hyprlock v7.0.0 was released with the fix for the issue
